### PR TITLE
Google Stackdriver Monitor

### DIFF
--- a/list.xml
+++ b/list.xml
@@ -85,4 +85,8 @@
 	<spider ident="Twitterbot">
 		<name>Twitterbot</name>
 	</spider>
+	<spider ident="GoogleStackdriverMonitoring">
+		<name>GoogleStackdriverMonitoring-UptimeChecks(https://cloud.google.com/monitoring)</name>
+		<url>https://cloud.google.com/monitoring</url>
+	</spider>
 </data>


### PR DESCRIPTION
I hope this is the correct entry. My Burning Board show "GoogleStackdriverMonitoring-UptimeChecks(https://cloud.google.com/monitoring)" as Browserident.